### PR TITLE
Misc improvements to the library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,7 @@ project(base64)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-
 include_directories(include)
 
-add_executable(${PROJECT_NAME} main.cpp)
-
+add_executable(roundtrip_test test/roundtrip_test.cpp)
+add_custom_command(TARGET roundtrip_test POST_BUILD COMMAND ./roundtrip_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,5 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include_directories(include)
 
 add_executable(roundtrip_test test/roundtrip_test.cpp)
+target_compile_options(roundtrip_test PRIVATE -Wall -Wextra -Woverflow -Wconversion)
 add_custom_command(TARGET roundtrip_test POST_BUILD COMMAND ./roundtrip_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -7,10 +7,10 @@
 namespace base64 {
 
 inline std::string get_base64_chars() {
-    static std::string base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                   "abcdefghijklmnopqrstuvwxyz"
-                                   "0123456789+/";
-    return base64_chars;
+  static std::string base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                    "abcdefghijklmnopqrstuvwxyz"
+                                    "0123456789+/";
+  return base64_chars;
 }
 
 inline std::string to_base64(std::string const &data) {
@@ -76,6 +76,6 @@ inline std::string from_base64(std::string const &data) {
   return decoded;
 }
 
-}
+} // namespace base64
 
 #endif // BASE_64_HPP

--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <string>
+#include <stdexcept>
 
 namespace base64 {
 
@@ -68,7 +69,7 @@ inline std::string from_base64(std::string const &data) {
         bit_stream = 0;
       }
     } else if (c != '=') {
-      return std::string{};
+      throw std::runtime_error{"Invalid base64 encoded data"};
     }
     counter++;
   }

--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -52,7 +52,7 @@ inline OutputBuffer encode_into(InputIterator begin, InputIterator end) {
   return encoded;
 }
 
-inline std::string to_base64(std::string const &data) {
+inline std::string to_base64(std::string_view data) {
 	return encode_into<std::string>(std::begin(data), std::end(data));
 }
 

--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -2,22 +2,18 @@
 #define BASE_64_HPP
 
 #include <algorithm>
-#include <string>
 #include <stdexcept>
+#include <string>
 
 namespace base64 {
 
-inline std::string get_base64_chars() {
-  static std::string base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                    "abcdefghijklmnopqrstuvwxyz"
-                                    "0123456789+/";
-  return base64_chars;
-}
+inline constexpr std::string_view base64_chars{"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                               "abcdefghijklmnopqrstuvwxyz"
+                                               "0123456789+/"};
 
 inline std::string to_base64(std::string const &data) {
   int counter = 0;
   uint32_t bit_stream = 0;
-  const std::string base64_chars = get_base64_chars();
   std::string encoded;
   int offset = 0;
   for (unsigned char c : data) {
@@ -52,7 +48,6 @@ inline std::string from_base64(std::string const &data) {
   size_t counter = 0;
   uint32_t bit_stream = 0;
   std::string decoded;
-  const std::string base64_chars = get_base64_chars();
   for (unsigned char c : data) {
     auto const num_val = base64_chars.find(c);
     if (num_val != std::string::npos) {

--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -57,7 +57,7 @@ inline std::string from_base64(std::string const &data) {
     auto num_val = base64_chars.find(c);
     if (num_val != std::string::npos) {
       offset = 18 - counter % 4 * 6;
-      bit_stream += num_val << offset;
+      bit_stream += static_cast<uint32_t>(num_val) << offset;
       if (offset == 12) {
         decoded += static_cast<char>(bit_stream >> 16 & 0xff);
       }

--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -22,6 +22,7 @@ inline OutputBuffer encode_into(InputIterator begin, InputIterator end) {
   uint32_t bit_stream = 0;
   size_t offset = 0;
   OutputBuffer encoded;
+	encoded.reserve(static_cast<size_t>(1.5 * static_cast<double>(std::distance(begin, end))));
   while(begin != end) {
 		auto const num_val = static_cast<unsigned char>(*begin);
     offset = 16 - counter % 3 * 8;
@@ -66,6 +67,7 @@ inline OutputBuffer decode_into(std::string_view data) {
   size_t counter = 0;
   uint32_t bit_stream = 0;
   OutputBuffer decoded;
+	decoded.reserve(std::size(data));
   for (unsigned char c : data) {
     auto const num_val = base64_chars.find(c);
     if (num_val != std::string::npos) {

--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace base64 {
 

--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -45,7 +45,7 @@ inline std::string to_base64(std::string const &data) {
 }
 
 template<class OutputBuffer>
-inline OutputBuffer decode_into(std::string const &data) {
+inline OutputBuffer decode_into(std::string_view data) {
 	using value_type = typename OutputBuffer::value_type;
 	static_assert(std::is_same_v<value_type, char>
 		|| std::is_same_v<value_type, unsigned char>
@@ -77,7 +77,7 @@ inline OutputBuffer decode_into(std::string const &data) {
   return decoded;
 }
 
-inline std::string from_base64(std::string const &data) {
+inline std::string from_base64(std::string_view data) {
 	return decode_into<std::string>(data);
 }
 

--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -12,10 +12,10 @@ inline constexpr std::string_view base64_chars{"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                                "0123456789+/"};
 
 inline std::string to_base64(std::string const &data) {
-  int counter = 0;
+  size_t counter = 0;
   uint32_t bit_stream = 0;
+  size_t offset = 0;
   std::string encoded;
-  int offset = 0;
   for (unsigned char c : data) {
     auto num_val = static_cast<unsigned int>(c);
     offset = 16 - counter % 3 * 8;

--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -48,15 +48,14 @@ inline std::string to_base64(std::string const &data) {
 }
 
 inline std::string from_base64(std::string const &data) {
-  int counter = 0;
+  size_t counter = 0;
   uint32_t bit_stream = 0;
   std::string decoded;
-  int offset = 0;
   const std::string base64_chars = get_base64_chars();
   for (unsigned char c : data) {
-    auto num_val = base64_chars.find(c);
+    auto const num_val = base64_chars.find(c);
     if (num_val != std::string::npos) {
-      offset = 18 - counter % 4 * 6;
+      auto const offset = 18 - counter % 4 * 6;
       bit_stream += static_cast<uint32_t>(num_val) << offset;
       if (offset == 12) {
         decoded += static_cast<char>(bit_stream >> 16 & 0xff);
@@ -69,7 +68,7 @@ inline std::string from_base64(std::string const &data) {
         bit_stream = 0;
       }
     } else if (c != '=') {
-      return std::string();
+      return std::string{};
     }
     counter++;
   }

--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -28,26 +28,26 @@ inline OutputBuffer encode_into(InputIterator begin, InputIterator end) {
     offset = 16 - counter % 3 * 8;
     bit_stream += num_val << offset;
     if (offset == 16) {
-      encoded.push_back(base64_chars.at(bit_stream >> 18 & 0x3f));
+      encoded.push_back(base64_chars[bit_stream >> 18 & 0x3f]);
     }
     if (offset == 8) {
-      encoded.push_back(base64_chars.at(bit_stream >> 12 & 0x3f));
+      encoded.push_back(base64_chars[bit_stream >> 12 & 0x3f]);
     }
     if (offset == 0 && counter != 3) {
-      encoded.push_back(base64_chars.at(bit_stream >> 6 & 0x3f));
-      encoded.push_back(base64_chars.at(bit_stream & 0x3f));
+      encoded.push_back(base64_chars[bit_stream >> 6 & 0x3f]);
+      encoded.push_back(base64_chars[bit_stream & 0x3f]);
       bit_stream = 0;
     }
     ++counter;
 		++begin;
   }
   if (offset == 16) {
-    encoded.push_back(base64_chars.at(bit_stream >> 12 & 0x3f));
+    encoded.push_back(base64_chars[bit_stream >> 12 & 0x3f]);
     encoded.push_back('=');
 		encoded.push_back('=');
   }
   if (offset == 8) {
-    encoded.push_back(base64_chars.at(bit_stream >> 6 & 0x3f));
+    encoded.push_back(base64_chars[bit_stream >> 6 & 0x3f]);
 		encoded.push_back('=');
   }
   return encoded;

--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 #clang-format -verbose -i -style=file src/*.cpp
-#clang-format -verbose -i -style=file test/*.cpp
+clang-format -verbose -i -style=file test/*.cpp
 clang-format -verbose -i -style=file include/*.hpp

--- a/test/roundtrip_test.cpp
+++ b/test/roundtrip_test.cpp
@@ -1,0 +1,25 @@
+#include "../include/base64.hpp"
+
+#include <iostream>
+#include <type_traits>
+
+int main() {
+  std::string original;
+  for (int i = 0; i < 1024; i++) {
+    original += char(std::rand());
+  }
+
+  std::cout << "char is "
+            << (std::is_signed<char>::value ? "signed" : "unsigned")
+            << std::endl;
+
+  auto encoded = base64::to_base64(original);
+  auto s = base64::from_base64(encoded);
+  if (s == original) {
+    std::cout << "PASS!!\n";
+    return 0;
+  } else {
+    std::cout << "FAIL!!\n";
+    return 1;
+  }
+}


### PR DESCRIPTION
This PR

* Adds a simple roundtrip test covering #2
* Enables some compiler warnings for use with the test code
* Fixes some issues with int/size_t (in short: never use int, unless for simple cases)
* Makes use of C++17 features (You said modern C++, but I think it would have compiled in C++98 mode)
* Makes it possible to decode/encode to/from std::vector of std::byte, which may be more common storage for binary data
* Add code to reserve space in the output buffer