### PR TITLE
fix: add dependency cstdint

### DIFF
--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -1,6 +1,7 @@
 #ifndef BASE_64_HPP
 #define BASE_64_HPP
 
+#include <cstdint>
 #include <algorithm>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
`uint32_t` is defined in #include<cstdint>. You need to include this for compatibility. Check this: https://en.cppreference.com/w/cpp/types/integer