### PR TITLE
Added missing #include <type_traits>

### DIFF
--- a/include/base64.hpp
+++ b/include/base64.hpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 #if defined(__cpp_lib_bit_cast)
 #include <bit>  // For std::bit_cast.


### PR DESCRIPTION
It's using std::is_trivially_copyable_v, which is defined in that header.