### PR TITLE
Minor fixes and improved unit testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,12 @@ if (BASE64_ENABLE_TESTING)
 
   add_executable(base64_tests test/base64_tests.cpp)
   target_link_libraries(base64_tests PRIVATE base64)
-
   target_link_libraries(base64_tests PRIVATE GTest::gtest GTest::gtest_main)
-
   add_test(NAME base64_tests COMMAND base64_tests)
+
+  add_executable(modp_b64_tests test/modp_b64_tests.cpp)
+  target_link_libraries(modp_b64_tests PRIVATE base64)
+  target_link_libraries(modp_b64_tests PRIVATE GTest::gtest GTest::gtest_main)
+  add_test(NAME modp_b64_tests COMMAND modp_b64_tests)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if (BASE64_ENABLE_TESTING)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        750d67d809700ae8fca6d610f7b41b71aa161808
+    GIT_TAG        b514bdc898e2951020cbdca1304b75f5950d1f59
     GIT_PROGRESS   TRUE
     SYSTEM
   )

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ int main() {
 ## Notes
 This library relies on C++17 but will exploit some C++20 features if available (e.g. `bit_cast`).
 
-There are many implementations available and it may be worth looking at those. A benchmark of various c/c++ base64 implementations can be found at https://github.com/gaspardpetit/base64/
+There are many implementations available and it may be worth looking at those. A benchmark of various c/c++ base64 implementations can be found at https://github.com/gaspardpetit/base64/ with summary results at:
+- https://rawcdn.githack.com/gaspardpetit/base64/main/result/result.html (presented as `base64tl`)
 
 This implementation here adopts the approach of Nick Galbreath's `modp_b64` library also used by chromium (e.g.  https://github.com/chromium/chromium/tree/main/third_party/modp_b64 ) but offers it as a c++ single header file. This choice was based on the good computational performance of the underpinning algorithm. We also decided to avoid relying on a c++ `union` to perform type punning as this, while working in practice, is strictly speaking undefined behaviour in c++: https://en.wikipedia.org/wiki/Type_punning#Use_of_union
 
-Faster c/c++ implementations exist althrough these likely exploit simd / openmp or similar acceleration techniques:
+Faster c/c++ implementations exist although these do not come as a single header library and exploit simd / openmp or similar acceleration techniques:
 - https://github.com/aklomp/base64
-- https://github.com/lemire/fastbase64 (From a [blog post](https://lemire.me/blog/2018/01/17/ridiculously-fast-base64-encoding-and-decoding/) by the authors: "My understanding is that our good results have been integrated in [Klomp’s base64 library](https://github.com/aklomp/base64).")
-- Other implementations related to the one by lemire: https://github.com/WojciechMula/base64-avx512 and https://github.com/WojciechMula/base64simd
+- https://github.com/simdutf/simdutf
 - https://github.com/powturbo/Turbo-Base64 (Note that this is licensed under GPL 3.0)
 
 Many other C++ centric appraches exists although they seem to focus on readibility or genericity at the cost of performance, e.g.:

--- a/test/base64_tests.cpp
+++ b/test/base64_tests.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "../include/base64.hpp"
 
@@ -181,7 +182,6 @@ TEST(Base64Decode, DecodesMissingIssueExample) {
 
 // NOLINTNEXTLINE
 TEST(Base64Decode, DecodesEmptyString) {
-  std::string const input{};
   std::string expected{};
   auto const actual{base64::from_base64("")};
 

--- a/test/modp_b64_tests.cpp
+++ b/test/modp_b64_tests.cpp
@@ -1,0 +1,121 @@
+// Test suite ported
+// https://github.com/client9/stringencoders/blob/master/test/modp_b64_test.c
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "../include/base64.hpp"
+
+// NOLINTNEXTLINE
+TEST(Base64Encode, Padding) {
+  // Test 1-6 bytes input and decode
+  {
+    /* 1 in, 4 out */
+    std::string const input{1};
+    auto const encoded{base64::to_base64(input)};
+    ASSERT_EQ(4, encoded.size());
+    auto const decoded{base64::from_base64(encoded)};
+    ASSERT_EQ(input, decoded);
+  }
+  {
+    /* 2 in, 4 out */
+    std::string const input{1, 1};
+    auto const encoded{base64::to_base64(input)};
+    ASSERT_EQ(4, encoded.size());
+    auto const decoded{base64::from_base64(encoded)};
+    ASSERT_EQ(input, decoded);
+  }
+  {
+    /* 3 in, 4 out */
+    std::string const input{1, 1, 1};
+    auto const encoded{base64::to_base64(input)};
+    ASSERT_EQ(4, encoded.size());
+    auto const decoded{base64::from_base64(encoded)};
+    ASSERT_EQ(input, decoded);
+  }
+  {
+    /* 4 in, 8 out */
+    std::string const input{1, 1, 1, 1};
+    auto const encoded{base64::to_base64(input)};
+    ASSERT_EQ(8, encoded.size());
+    auto const decoded{base64::from_base64(encoded)};
+    ASSERT_EQ(input, decoded);
+  }
+  {
+    /* 5 in, 8 out */
+    std::string const input{1, 1, 1, 1, 1};
+    auto const encoded{base64::to_base64(input)};
+    ASSERT_EQ(8, encoded.size());
+    auto const decoded{base64::from_base64(encoded)};
+    ASSERT_EQ(input, decoded);
+  }
+  {
+    /* 6 in, 8 out */
+    std::string const input{1, 1, 1, 1, 1, 6};
+    auto const encoded{base64::to_base64(input)};
+    ASSERT_EQ(8, encoded.size());
+    auto const decoded{base64::from_base64(encoded)};
+    ASSERT_EQ(input, decoded);
+  }
+}
+
+// NOLINTNEXTLINE
+TEST(Base64Encode, EncodeDecode) {
+  // Test all 17M 3 bytes inputs to encoder, decode
+  // and make sure it's equal.
+  for (int i = 0; i < 256; ++i) {
+    for (int j = 0; j < 256; ++j) {
+      for (int k = 0; k < 256; ++k) {
+        std::string const input{static_cast<char>(i), static_cast<char>(j),
+                                static_cast<char>(k)};
+        auto const encoded{base64::to_base64(input)};
+        ASSERT_EQ(4, encoded.size());
+        auto const decoded{base64::from_base64(encoded)};
+        ASSERT_EQ(input, decoded);
+      }
+    }
+  }
+}
+
+// NOLINTNEXTLINE
+TEST(Base64Encode, DecodeErrors) {
+  {
+    // test bad input -  all combinations
+    char goodchar = 'A';
+    char badchar = '~';
+    std::array<std::uint8_t, 4> decode;
+    for (int i = 1; i < 16; ++i) {
+      decode[0] = static_cast<char>(((i & 0x01) == 0) ? goodchar : badchar);
+      decode[1] = static_cast<char>(((i & 0x02) == 0) ? goodchar : badchar);
+      decode[2] = static_cast<char>(((i & 0x04) == 0) ? goodchar : badchar);
+      decode[3] = static_cast<char>(((i & 0x08) == 0) ? goodchar : badchar);
+
+      ASSERT_THROW(
+          base64::decode_into<std::string>(decode.begin(), decode.end()),
+          std::runtime_error);
+    }
+  }
+  {
+    // test just 1-4 padchars
+    for (int i = 1; i <= 4; ++i) {
+      std::vector<char> decode(i, '=');
+      ASSERT_THROW(
+          base64::decode_into<std::string>(decode.begin(), decode.end()),
+          std::runtime_error);
+    }
+  }
+  {
+    // Test good+3 pad chars (should be impossible)
+    std::string decode("A===");
+    ASSERT_THROW(base64::decode_into<std::string>(decode.begin(), decode.end()),
+                 std::runtime_error);
+  }
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/roundtrip_test.cpp
+++ b/test/roundtrip_test.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 #include <type_traits>
 #include <vector>
 


### PR DESCRIPTION
Note that the cpplint failure for namespace indentation appears to be a false positive:
https://github.com/tvercaut/base64/issues/3